### PR TITLE
remove unused dependency on "merge"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5678,11 +5678,6 @@
         "readable-stream": "^2.0.1"
       }
     },
-    "merge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
-    },
     "merge-stream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,5 @@
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3"
   },
-  "dependencies": {
-    "merge": "^1.2.1"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Hi @artka54, thanks for this useful and small library!

Currently, the package declares a dependency on an old version of the `merge` npm package [with a security problem](https://github.com/advisories/GHSA-7wpw-2hjm-89gp) but does not actually use it anywhere. This small PR removes the dependency.

Thank you!